### PR TITLE
provide split off testing for the templating stuff

### DIFF
--- a/docker-test.sh
+++ b/docker-test.sh
@@ -4,11 +4,21 @@
 dckr_cnt_nm=${1:-"emobon_arup"}
 dckr_img_nm=${2:-"emobon_arup:latest"}
 
-#build a temp space and fill it with the content
-TMPDIR=$(mktemp -d) && echo "using TMPDIR=${TMPDIR}"
-(cd ./tests/data/ && cp -r . ${TMPDIR})
-cp ./tests/test-work.yml ${TMPDIR}/test-work.yml
-tree ${TMPDIR}
+#check for .env file and use it if available
+if [[ -f .env ]]; then
+  source .env
+fi
+#create temp space if not provided from env
+if [[ -z "${TEST_OUTPUTFOLDER}" ]]; then
+  TMPDIR=$(mktemp -d) 
+  TEST_OUTPUTFOLDER=${TMPDIR}
+fi
+echo "using TEST_OUTPUTFOLDER=${TEST_OUTPUTFOLDER}"
+
+# fill the outfolder with the content to test 
+(cd ./tests/data/ && cp -r . ${TEST_OUTPUTFOLDER})
+cp ./tests/test-work.yml ${TEST_OUTPUTFOLDER}/test-work.yml
+cp -r ./tests/templates ${TEST_OUTPUTFOLDER}/test-templates
 
 
 #check if an image exists and build it if not
@@ -22,6 +32,7 @@ docker run --rm \
   --name emo-bon_${dckr_cnt_nm} \
   --volume ${TMPDIR}:/rocrateroot \
   --env ARUP_WORK=test-work.yml \
+  --env ARUP_TEMPLATES=test-templates \
   --env SAMPLE_MAT_ID='test_sm_id' \
   ${dckr_img_nm}
 

--- a/dotenv.example
+++ b/dotenv.example
@@ -1,4 +1,17 @@
 # Usage:
 # Make a copy of this file to a local .env file and change settings as needed
 # ----
-# There are currently no environment variable this service will pick up on
+# Set the output_folder to use during test 
+#  - if not set a tmp folder during test will be created and removed
+#TEST_OUTFOLDER=/tmp/test_arup
+# --
+# Set the docker-guest /path/to/the/work.yml to use in processing
+#  - relative paths are resolved vs. /rocrateroot
+#  - if not set /arup/work.yml is assumed
+#ARUP_WORK=/arup/work.yml
+# --
+# Set the docker-guest /path/to/the/templates/ folder to use in processing
+#  - relative paths are resolved vs. /rocrateroot
+#  - if not set /arup/templates/ is assumed
+#ARUP_TEMPLATES=/arup/templates/
+# --

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -162,7 +162,6 @@ class SubytJobs:
                 for line in inf:
                     outf.write(line)
 
-
     def _prepare(self):
         """Executes the prepare-file-jobs in the workfile."""
         log.debug("running the prepare jobs...")
@@ -189,19 +188,24 @@ class SubytJobs:
 
 def _main(
     *,
-    workfile: str = None,
     rocrateroot: str = "/rocrateroot",
-    templateroot: str = "/arup/templates",
+    workfile: str | None = None,
+    templateroot: str | None = None,
     resultsroot: str | None = None,
 ) -> None:
     rocrateroot = Path(rocrateroot)
 
     # allow env var to be relative to rocrateroot or absolute
-    workfile = workfile or os.environ.get("ARUP_WORK", "/arup/work.yml")
-    workfile = rocrateroot / Path(workfile)
+    workfile = workfile or os.getenv("ARUP_WORK", "/arup/work.yml")
+    workfile = rocrateroot / workfile
 
-    templateroot = Path(templateroot)
+    templateroot = templateroot or os.getenv(
+        "ARUP_TEMPLATES", "/arup/templates"
+    )
+    templateroot = rocrateroot / templateroot
+
     resultsroot = resultsroot or rocrateroot
+    resultsroot = Path(resultsroot)
 
     uplifting = SubytJobs(workfile, rocrateroot, templateroot, resultsroot)
     uplifting.run()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest
 black
 flake8
 isort
+python-dotenv

--- a/templates/test-template-toremove.ttl
+++ b/templates/test-template-toremove.ttl
@@ -1,0 +1,16 @@
+{# this is here just waiting to be replaced by actual templates for analysis results #}
+{%- if ctrl.isFirst -%}
+@prefix ex:   <http://example.org/>.
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#>.
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix dc: <http://purl.org/dc/elements/1.1/>.
+{%- endif %}
+
+{{ uritexpand(domain + "countries/{code}", _) | uri }}
+    a ex:Country;
+    rdfs:label {{ _.label | xsd('@en')}};
+    skos:definition {{ _.description | xsd( '@en') }};
+    dc:identifier {{ (sample_mat_id  + '::' +  ctrl.index|string  + '::' +  _.code) | xsd('string') }}.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
+from contextlib import contextmanager
 from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_file_location
 from logging import Logger, getLogger
+import os
+from pathlib import Path
+import tempfile
+
+from dotenv import load_dotenv
 
 log: Logger = getLogger(__name__)
 
@@ -17,3 +23,25 @@ def load_source(modname, filename):
 
 
 entrypoint = load_source("entrypoint", "entrypoint.py")
+root = Path(entrypoint.__file__).parent
+
+
+@contextmanager
+def tempdir_path():
+    load_dotenv()
+    tmpdir = os.getenv("TEST_OUTFOLDER")
+    if tmpdir:
+        tmpdir = Path(tmpdir)
+        tmpdir.mkdir(exist_ok=True, parents=True)
+        log.info(
+            f"Configured outfolder {tmpdir=} "
+            "allows the output to be manually verified."
+        )
+        yield tmpdir
+    else:
+        log.info(
+            "Temporary outfolder removed at end of test. "
+            "Use environment TEST_OUTFOLDER to specify a permanent one."
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_file_location
+from logging import Logger, getLogger
+
+log: Logger = getLogger(__name__)
+
+
+def load_source(modname, filename):
+    loader = SourceFileLoader(modname, filename)
+    spec = spec_from_file_location(modname, filename, loader=loader)
+    module = module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
+
+entrypoint = load_source("entrypoint", "entrypoint.py")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import tempfile
 
 from dotenv import load_dotenv
 
-log: Logger = getLogger(__name__)
+log: Logger = getLogger("tests")
 
 
 def load_source(modname, filename):

--- a/tests/templates/test-template.ttl
+++ b/tests/templates/test-template.ttl
@@ -1,12 +1,15 @@
+{%- if ctrl.isFirst -%}
 @prefix ex:   <http://example.org/>.
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#>.
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix skos: <http://www.w3.org/2004/02/skos/core#>.
 @prefix dc: <http://purl.org/dc/elements/1.1/>.
+{%- endif %}
 
 {{ uritexpand(domain + "countries/{code}", _) | uri }}
     a ex:Country;
     rdfs:label {{ _.label | xsd('@en')}};
     skos:definition {{ _.description | xsd( '@en') }};
     dc:identifier {{ (my_var_name  + '::' +  ctrl.index|string  + '::' +  _.code) | xsd('string') }}.
+

--- a/tests/test-work.yml
+++ b/tests/test-work.yml
@@ -4,15 +4,18 @@ vars:
   - name: domain
     value: https://data.emobon.embrc.eu/
 
-prepare:
-  - input: test-input.txt
-    output: test-input.csv
-    header: "code,label,description"
+# prepare:
+#   - input: test-input.txt
+#     output: test-input.csv
+#     header: "code,label,description"
 
 subyt:
-  - source: test-input.csv
+  - source: test-input.txt+ext=csv+header=code,label,description
     sink: test-output.ttl
     template_name: test-template.ttl
-  - source: test-input.csv
+  - source:
+      path: test-input.txt
+      mime: text/csv
+      header: code,label,description
     sink: test-output2.ttl
     template_name: test-template.ttl

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,53 +1,36 @@
 import filecmp
-import os
-import tempfile
 from pathlib import Path
-
-from conftest import entrypoint, log
-from dotenv import load_dotenv
+from conftest import entrypoint, root, tempdir_path
 from rdflib import Graph
 from sema.commons.glob import getMatchingGlobPaths
 
 
-def test_cli():
-    assert entrypoint._main
-    root = Path(entrypoint.__file__).parent
+def verify_build(outdir: Path) -> None:
+    # verify results
+    resultfiles = getMatchingGlobPaths(
+        outdir, includes=["*.ttl"], makeRelative=False
+    )
+    assert len(resultfiles) == 2
+    # compare the ttl files, should be exactly the same
+    assert filecmp.cmp(resultfiles[0], resultfiles[1], shallow=True)
+    # try parsing the ttl files too
+    for rf in resultfiles:
+        assert rf.exists()
+        assert rf.stat().st_size > 0
+        Graph().parse(str(rf), format="ttl")
 
-    def build_and_verify(outdir: str | Path) -> None:
-        outdir = Path(outdir)  # ensure Path type
+
+def test_basics():
+    assert entrypoint._main
+
+    def build_and_verify(outdir: Path) -> None:
         entrypoint._main(
             workfile=root / "tests/test-work.yml",
             rocrateroot=root / "tests/data",
             templateroot=root / "tests/templates",
             resultsroot=outdir,
         )
-        # verify results
-        resultfiles = getMatchingGlobPaths(
-            outdir, includes=["*.ttl"], makeRelative=False
-        )
-        assert len(resultfiles) == 2
-        # compare the ttl files, should be exactly the same
-        assert filecmp.cmp(resultfiles[0], resultfiles[1], shallow=True)
-        # try parsing the ttl files too
-        for rf in resultfiles:
-            assert rf.exists()
-            assert rf.stat().st_size > 0
-            Graph().parse(str(rf), format="ttl")
+        verify_build(outdir)
 
-    load_dotenv()
-    tmpdir = os.getenv("TEST_OUTFOLDER")
-    if tmpdir:
-        tmpdir = Path(tmpdir)
-        tmpdir.mkdir(exist_ok=True, parents=True)
-        log.info(
-            f"Configured outfolder {tmpdir=} "
-            "allows the output to be manually verified."
-        )
+    with tempdir_path() as tmpdir:
         build_and_verify(tmpdir)
-    else:
-        log.info(
-            "Temporary outfolder removed at end of test. "
-            "Use environment TEST_OUTFOLDER to specify a permanent one."
-        )
-        with tempfile.TemporaryDirectory() as tmpdir:
-            build_and_verify(tmpdir)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,36 +1,62 @@
 import filecmp
 from pathlib import Path
-from conftest import entrypoint, root, tempdir_path
+from conftest import entrypoint, root, tempdir_path, log
 from rdflib import Graph
-from sema.commons.glob import getMatchingGlobPaths
 
 
-def verify_build(outdir: Path) -> None:
-    # verify results
-    resultfiles = getMatchingGlobPaths(
-        outdir, includes=["*.ttl"], makeRelative=False
-    )
-    assert len(resultfiles) == 2
-    # compare the ttl files, should be exactly the same
-    assert filecmp.cmp(resultfiles[0], resultfiles[1], shallow=True)
-    # try parsing the ttl files too
-    for rf in resultfiles:
-        assert rf.exists()
-        assert rf.stat().st_size > 0
-        Graph().parse(str(rf), format="ttl")
+def verify_build(outdir: Path, workfile: Path) -> None:
+    # load the workfile, grab the expected outputs
+    log.debug(f"Verifying build in {outdir}")
+    log.debug(f"Using workfile {workfile}")
+    workdict = entrypoint.SubytJobs.load_instructions(workfile)
+    log.debug(f"Workfile loaded and subyt tasks found: {workdict['subyt']}")
+    expectedfiles: list[Path] = [
+        outdir / job.get('sink')
+        for job in workdict["subyt"]
+    ]
+
+    for ef in expectedfiles:
+        assert ef.exists()
+        assert ef.stat().st_size > 0
+        Graph().parse(str(ef), format="ttl")
 
 
 def test_basics():
+    log.debug("test_basics")
     assert entrypoint._main
 
     def build_and_verify(outdir: Path) -> None:
+        workfile = root / "tests/test-work.yml"
         entrypoint._main(
-            workfile=root / "tests/test-work.yml",
+            workfile=workfile,
             rocrateroot=root / "tests/data",
             templateroot=root / "tests/templates",
             resultsroot=outdir,
         )
-        verify_build(outdir)
+        verify_build(outdir, workfile)
+        assert filecmp.cmp(
+            outdir / "test-output.ttl",
+            outdir / "test-output2.ttl",
+        )
+
+    with tempdir_path() as tmpdir:
+        build_and_verify(tmpdir)
+
+
+def test_arup_templating():
+    log.debug("test_arup_templating")
+    assert entrypoint._main
+
+    def build_and_verify(outdir: Path) -> None:
+        workfile = root / "work.yml"
+        entrypoint._main(
+            workfile=workfile,
+            rocrateroot=root / "tests/data",
+            templateroot=root / "templates",
+            resultsroot=outdir,
+        )
+        verify_build(outdir, workfile)
+        # TODO: verify the templating more extensively
 
     with tempdir_path() as tmpdir:
         build_and_verify(tmpdir)

--- a/work.yml
+++ b/work.yml
@@ -4,8 +4,16 @@ vars: # list name,value pairs available for substitution in templates
   - name: sample_mat_id
     value: !resolve "{SAMPLE_MAT_ID}" # use !resolve "text {env_variable} values" to inject from .env
 
+prepare:
+  # multiple prepare jobs can be specified
+  # note: ext=csv hint and header can now also be added to subyt-source directly
+  - input: ./test-input.txt # ./path/relative/to/rocrateroot-volume/
+    output: ./test-input.csv # ./path/relative/to/rocrateroot-volume/
+    header: "code,label,description"
+
 subyt:
   # multiple jobs can be specified
-  - source: ./somewhere/input-file.csv # ./path/relative/to/rocrateroot-volume/
-    sink: ./somewhere/output-file.ttl # ./path/relative/to/rocrateroot-volume/
-    template_name: test-output.ttl.j2 # ./name/relative/to/templates/
+  # below is to be replaced by actual anaylis - results work
+  - source: ./test-input.csv # ./path/relative/to/rocrateroot-volume/
+    sink: ./output-file.ttl # ./path/relative/to/rocrateroot-volume/
+    template_name: test-template-toremove.ttl # ./name/relative/to/templates/


### PR DESCRIPTION
fixes #13

introduces TEST_OUTFOLDER via dotenv
refactors some test setup
adds the new subyt "extended identifier" support

should allow for more assessments as needed for the actual templated uplifting